### PR TITLE
Investigate 404 error on create step 2

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -126,6 +126,8 @@ Route::prefix('partner')->name('partner.')->middleware(['auth', 'role:partner'])
 
     
     // Question Set Management
+    // Explicit route for alternate create URL to avoid 404 and {question_set} catch-all
+    Route::get('question-sets/create-step2', [QuestionSetController::class, 'create'])->name('question-sets.create-step2');
     Route::resource('question-sets', QuestionSetController::class);
     Route::post('question-sets/{questionSet}/add-questions', [QuestionSetController::class, 'addQuestions'])->name('question-sets.add-questions');
     Route::delete('question-sets/{questionSet}/remove-question/{question}', [QuestionSetController::class, 'removeQuestion'])->name('question-sets.remove-question');


### PR DESCRIPTION
Add explicit route for `partner/question-sets/create-step2` to resolve a 404 error.

The existing resource route `question-sets/{question_set}` was incorrectly interpreting `create-step2` as a `{question_set}` ID, leading to a 404. This explicit route ensures `create-step2` is correctly mapped to the `create` action before the dynamic resource route takes precedence.

---
<a href="https://cursor.com/background-agent?bcId=bc-16b2e211-84ea-46ff-8b4f-cb57c875ee49">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-16b2e211-84ea-46ff-8b4f-cb57c875ee49">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

