### PR TITLE
Investigate 404 error on create step 2

### DIFF
--- a/app/Http/Controllers/QuestionSetController.php
+++ b/app/Http/Controllers/QuestionSetController.php
@@ -22,6 +22,11 @@ class QuestionSetController extends Controller
         return view('partner.question-sets.create');
     }
 
+    public function createStep2(Request $request)
+    {
+        return view('partner.question-sets.create-step2');
+    }
+
     public function store(Request $request)
     {
         $request->validate([

--- a/resources/views/partner/question-sets/create-step2.blade.php
+++ b/resources/views/partner/question-sets/create-step2.blade.php
@@ -1,0 +1,28 @@
+@extends('layouts.app')
+
+@section('title', 'Create Question Set - Step 2')
+
+@section('content')
+<div class="max-w-3xl mx-auto">
+    <div class="flex justify-between items-center mb-6">
+        <div>
+            <h1 class="text-3xl font-bold text-gray-900 dark:text-white">Create Question Set - Step 2</h1>
+            <p class="text-gray-600 dark:text-gray-400">Continue setting up your question set</p>
+        </div>
+        <a href="{{ route('partner.question-sets.index') }}" 
+           class="bg-gray-500 hover:bg-gray-600 text-white px-4 py-2 rounded-lg">
+            Back to Question Sets
+        </a>
+    </div>
+
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
+        <p class="text-gray-700 dark:text-gray-300">This is a placeholder for Step 2 of the question set creation process. Add your step-2 form or actions here.</p>
+
+        <div class="mt-6 flex gap-3 justify-end">
+            <a href="{{ route('partner.question-sets.create') }}" class="px-4 py-2 rounded-md bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200">Back to Step 1</a>
+            <a href="{{ route('partner.question-sets.index') }}" class="px-4 py-2 rounded-md bg-primaryGreen hover:bg-green-600 text-white">Finish</a>
+        </div>
+    </div>
+</div>
+@endsection 
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -127,6 +127,7 @@ Route::prefix('partner')->name('partner.')->middleware(['auth', 'role:partner'])
     
     // Question Set Management
     Route::resource('question-sets', QuestionSetController::class);
+    Route::get('question-sets/create-step2', [QuestionSetController::class, 'createStep2'])->name('question-sets.create-step2');
     Route::post('question-sets/{questionSet}/add-questions', [QuestionSetController::class, 'addQuestions'])->name('question-sets.add-questions');
     Route::delete('question-sets/{questionSet}/remove-question/{question}', [QuestionSetController::class, 'removeQuestion'])->name('question-sets.remove-question');
     


### PR DESCRIPTION
Add `partner/question-sets/create-step2` route and view to resolve a 404 error for the missing page.

---
<a href="https://cursor.com/background-agent?bcId=bc-e0dced19-f652-4785-9a47-2d086a996e2f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e0dced19-f652-4785-9a47-2d086a996e2f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

